### PR TITLE
feat: update Google Analytics ID to G-T194PS9EXJ

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,15 @@
     <link rel="icon" type="image/png" href="https://i.imgur.com/t2rcfkO.png" />
 
     <!-- Google Analytics - Script (en producción) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-506728974"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-T194PS9EXJ"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-506728974');
+      gtag('config', 'G-T194PS9EXJ');
+      gtag('set', 'user_properties', {
+        'custom_user_property': 'value'
+      });
     </script>
   </head>
   <body>


### PR DESCRIPTION
This commit updates the `index.html` file to replace the previous Google Analytics tracking ID with the new one provided by the user (G-T194PS9EXJ).

It also includes the `gtag('set', 'user_properties', ...)` line as requested, to allow for enhanced user tracking.