### PR TITLE
Fix(simulator): Relax URL validation for design images

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -677,12 +677,12 @@ const App = () => {
                       <button
                         onClick={() => {
                           const isValidImageUrl = (url) => {
-                            return /\.(jpg|jpeg|png|webp|gif)$/i.test(url);
+                            return url.startsWith('http://') || url.startsWith('https');
                           };
                           if (isValidImageUrl(designUrl)) {
                             setDesignImage(designUrl);
                           } else {
-                            alert('URL inválida. Por favor, introduce una URL de una imagen válida (jpg, jpeg, png, gif, webp).');
+                            alert('URL inválida. Por favor, introduce una URL de una imagen válida que empiece con http:// o https://.');
                           }
                         }}
                         className="p-2 bg-primary-accent rounded-lg text-background hover:bg-opacity-80"

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -81,7 +81,7 @@ test('should not update the design image with an invalid URL', async () => {
   const loadButton = screen.getByRole('button', { name: /Cargar diseño desde URL/i });
 
   // 3. Simulate user input with an invalid URL
-  fireEvent.change(urlInput, { target: { value: 'https://not-a-valid-image-url.com' } });
+  fireEvent.change(urlInput, { target: { value: 'not-a-valid-url' } });
 
   // 4. Click the load button
   fireEvent.click(loadButton);
@@ -91,4 +91,31 @@ test('should not update the design image with an invalid URL', async () => {
   // so `queryByAltText` will find it, and the test will fail.
   const designImage = screen.queryByAltText(/Diseño de tatuaje para simular/i);
   expect(designImage).not.toBeInTheDocument();
+});
+
+test('should update the design image with a valid URL without a file extension', async () => {
+  render(<App />);
+
+  // 1. Simulate uploading the simulator image to show the design controls
+  const simulatorUploadInput = screen.getByLabelText(/Seleccionar una foto/i);
+  const fakeFile = new File(['dummy'], 'test.png', { type: 'image/png' });
+  fireEvent.change(simulatorUploadInput, { target: { files: [fakeFile] } });
+
+  await screen.findByAltText(/Parte del cuerpo para simular tatuaje/i);
+
+  // 2. Get the URL input and the load button for the design
+  const urlInput = screen.getByPlaceholderText(/O pega una URL/i);
+  const loadButton = screen.getByRole('button', { name: /Cargar diseño desde URL/i });
+
+  // 3. Simulate user input with a valid URL that doesn't have a file extension
+  const validUrlWithoutExtension = 'https://source.unsplash.com/random';
+  fireEvent.change(urlInput, { target: { value: validUrlWithoutExtension } });
+
+  // 4. Click the load button
+  fireEvent.click(loadButton);
+
+  // 5. Check that the design image is rendered. This will fail before the fix.
+  const designImage = await screen.findByAltText(/Diseño de tatuaje para simular/i);
+  expect(designImage).toBeInTheDocument();
+  expect(designImage).toHaveAttribute('src', validUrlWithoutExtension);
 });


### PR DESCRIPTION
The tattoo simulator's URL validation for design images was too restrictive, only accepting URLs that ended with a specific set of image file extensions (e.g., .jpg, .png). This prevented users from using valid image URLs from sources like Unsplash that do not include a file extension.

This change replaces the regex-based validation with a simpler check that verifies if the URL starts with `http://` or `https://`. This makes the feature more flexible and improves the user experience.

A new test case has been added to verify that URLs without file extensions are now accepted. An existing test was also updated to use a truly invalid URL to ensure it continues to test the correct behavior.