### PR TITLE
Feat: Add local SEO text to hero section

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -42,6 +42,14 @@ const Hero = ({ whatsappLink, scrollToSection }) => {
         >
           Transformo tus ideas en arte permanente. Especialista en diseños minimalistas y transformación de tatuajes viejos.
         </motion.p>
+        <motion.p
+          className="text-base sm:text-lg text-text-secondary mb-8 max-w-3xl mx-auto leading-relaxed"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.7, duration: 0.6 }}
+        >
+          Tatuador profesional disponible con estudio móvil en Chacao, Baruta, El Hatillo, Los Teques y toda la Gran Caracas.
+        </motion.p>
         <motion.div
           className="flex flex-col sm:flex-row gap-4 justify-center"
           initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
In response to the user's request to improve local SEO, this commit adds a new line of text to the hero section specifying the service areas.

The text "Tatuador profesional disponible con estudio móvil en Chacao, Baruta, El Hatillo, Los Teques y toda la Gran Caracas." has been added to the `Hero.jsx` component. This change is intended to help capture more specific local search queries from users in those areas.

The change was visually verified using a Playwright script to ensure it displays correctly on the page.